### PR TITLE
Feature validate aud

### DIFF
--- a/lib/omniauth/okya/jwt_validator.rb
+++ b/lib/omniauth/okya/jwt_validator.rb
@@ -19,7 +19,7 @@ module OmniAuth
 
         @client_id = options.client_id
         @client_secret = options.client_secret
-        @audience = options.audiences << @client_id
+        @audiences = options.audiences << @client_id
       end
 
       # Decodes a JWT and verifies it's signature. Only tokens signed with the RS256 or HS256 signatures are supported.
@@ -92,7 +92,7 @@ module OmniAuth
 
         verify_iss(id_token)
         verify_sub(id_token)
-        # verify_aud(id_token)
+        verify_aud(id_token)
         verify_expiration(id_token, leeway)
         verify_iat(id_token)
         verify_nonce(id_token, nonce)

--- a/lib/omniauth/okya/jwt_validator.rb
+++ b/lib/omniauth/okya/jwt_validator.rb
@@ -19,7 +19,7 @@ module OmniAuth
 
         @client_id = options.client_id
         @client_secret = options.client_secret
-        @audiences = options.audiences << @client_id
+        @audience = options.audience
       end
 
       # Decodes a JWT and verifies it's signature. Only tokens signed with the RS256 or HS256 signatures are supported.
@@ -125,7 +125,7 @@ module OmniAuth
                 'Audience (aud) claim must be a string or array of strings present in the ID token'
         end
 
-        allowed_audiences = [@client_id, *@audiences].uniq
+        allowed_audiences = [@client_id, *@audience].uniq
 
         if audience.is_a?(Array)
           # Check if any of the token's audiences matches an allowed audience

--- a/lib/omniauth/okya/jwt_validator.rb
+++ b/lib/omniauth/okya/jwt_validator.rb
@@ -129,13 +129,13 @@ module OmniAuth
 
         if audience.is_a?(Array)
           # Check if any of the token's audiences matches an allowed audience
-          unless (audience - allowed_audiences).empty?
+          if (audience - allowed_audiences).present?
             raise OmniAuth::Okya::TokenValidationError,
                   "Audience (aud) claim mismatch in the ID token; expected values of #{allowed_audiences.join(', ')} but got #{audience.join(', ')}"
           end
 
         # Case 2: Token's audience is a string (e.g., "api1")
-        elsif !allowed_audiences.include?(audience)
+        elsif allowed_audiences.exclude?(audience)
           raise OmniAuth::Okya::TokenValidationError,
                 "Audience (aud) claim mismatch in the ID token; expected one of #{allowed_audiences.join(', ')} but got #{audience}"
         end

--- a/lib/omniauth/okya/jwt_validator.rb
+++ b/lib/omniauth/okya/jwt_validator.rb
@@ -19,6 +19,7 @@ module OmniAuth
 
         @client_id = options.client_id
         @client_secret = options.client_secret
+        @audience = options.audiences << @client_id
       end
 
       # Decodes a JWT and verifies it's signature. Only tokens signed with the RS256 or HS256 signatures are supported.
@@ -91,7 +92,7 @@ module OmniAuth
 
         verify_iss(id_token)
         verify_sub(id_token)
-        verify_aud(id_token)
+        # verify_aud(id_token)
         verify_expiration(id_token, leeway)
         verify_iat(id_token)
         verify_nonce(id_token, nonce)
@@ -122,12 +123,21 @@ module OmniAuth
         if !audience || !(audience.is_a?(String) || audience.is_a?(Array))
           raise OmniAuth::Okya::TokenValidationError,
                 'Audience (aud) claim must be a string or array of strings present in the ID token'
-        elsif audience.is_a?(Array) && !audience.include?(@client_id)
+        end
+
+        allowed_audiences = [@client_id, *@audiences].uniq
+
+        if audience.is_a?(Array)
+          # Check if any of the token's audiences matches an allowed audience
+          unless (audience & allowed_audiences).any?
+            raise OmniAuth::Okya::TokenValidationError,
+                  "Audience (aud) claim mismatch in the ID token; expected one of #{allowed_audiences.join(', ')} but got #{audience.join(', ')}"
+          end
+
+        # Case 2: Token's audience is a string (e.g., "api1")
+        elsif !allowed_audiences.include?(audience)
           raise OmniAuth::Okya::TokenValidationError,
-                "Audience (aud) claim mismatch in the ID token; expected #{@client_id} but was not one of #{audience.join(', ')}"
-        elsif audience.is_a?(String) && audience != @client_id
-          raise OmniAuth::Okya::TokenValidationError,
-                "Audience (aud) claim mismatch in the ID token; expected #{@client_id} but found #{audience}"
+                "Audience (aud) claim mismatch in the ID token; expected one of #{allowed_audiences.join(', ')} but got #{audience}"
         end
       end
 

--- a/lib/omniauth/okya/jwt_validator.rb
+++ b/lib/omniauth/okya/jwt_validator.rb
@@ -129,9 +129,9 @@ module OmniAuth
 
         if audience.is_a?(Array)
           # Check if any of the token's audiences matches an allowed audience
-          unless (audience & allowed_audiences).any?
+          unless (audience - allowed_audiences).empty?
             raise OmniAuth::Okya::TokenValidationError,
-                  "Audience (aud) claim mismatch in the ID token; expected one of #{allowed_audiences.join(', ')} but got #{audience.join(', ')}"
+                  "Audience (aud) claim mismatch in the ID token; expected values of #{allowed_audiences.join(', ')} but got #{audience.join(', ')}"
           end
 
         # Case 2: Token's audience is a string (e.g., "api1")


### PR DESCRIPTION
- Accepted audiences as an options
- Supports Multiple Audiences:
- The token's aud can now be either:
  - A single string (e.g., "api1").
  - An array of strings (e.g., ["api1", "api2"]).
- Validation:
  - Checks if the token's audience matches any of the allowed audiences (@client_id or @audiences)
### Note:  
Seem like we can add audience under `authorize_params` on initializer like [this](https://github.com/auth0/omniauth-auth0?tab=readme-ov-file#create-the-initializer), then it will auto validate and decode id token on callback api,  but we need to specify callback. I will test it separately

  
  Related PRs:
  - Okya-auth: https://github.com/okyaco/okya-auth/pull/176
  - Okya-web: https://github.com/okyaco/okya-web/pull/570